### PR TITLE
Set width of `layout__item`'s to `auto` as default

### DIFF
--- a/_objects.layout.scss
+++ b/_objects.layout.scss
@@ -51,20 +51,18 @@ $inuit-global-border-box: false !default;
      * 1. Cause columns to stack side-by-side.
      * 2. Space columns apart.
      * 3. Align columns to the tops of each other.
-     * 4. Full-width unless told to behave otherwise.
-     * 5. Required to combine fluid widths and fixed gutters.
+     * 4. Required to combine fluid widths and fixed gutters.
      */
     .#{$inuit-namespace}layout__item,
     %#{$inuit-namespace}layout__item {
         display: inline-block; /* [1] */
         padding-left: $inuit-layout-gutter; /* [2] */
         vertical-align: top; /* [3] */
-        width: 100%; /* [4] */
 
         @if $inuit-global-border-box == false {
-            -webkit-box-sizing: border-box; /* [5] */
-               -moz-box-sizing: border-box; /* [5] */
-                    box-sizing: border-box; /* [5] */
+            -webkit-box-sizing: border-box; /* [4] */
+               -moz-box-sizing: border-box; /* [4] */
+                    box-sizing: border-box; /* [4] */
         }
 
     }


### PR DESCRIPTION
I think it's useful to have the default `width` of `layout__item`'s to be `auto`. For example, if I want to have two elements next to each other, only taking up the necessary space, while being vertically aligned to the middle, I could do:

``` html
<div class="layout layout--middle">
  <div class="layout__item"><h2>Some tall content</h2></div>
  <div class="layout__item">Some more content bumped up next to my sibling</div>
</div>
```

If I ever want to specify the `width` of a `layout__item`, I simply use the width classes, as mentioned in `objects.layout`'s docs:

``` html
<div class="layout layout--middle">
  <div class="layout__item one-half"><h2>Some tall content</h2></div>
  <div class="layout__item one-half">Some content taking up the other half</div>
</div>
```

I'm not sure what the benefit is of the default `width` being `100%`. It seems like one could easily add the `one-whole` class to their `layout__item`'s to achieve it.
