### PR TITLE
Remove moz vendor prefix

### DIFF
--- a/_objects.layout.scss
+++ b/_objects.layout.scss
@@ -70,7 +70,6 @@ $inuit-global-border-box: false !default;
 
         @if $inuit-global-border-box == false {
             -webkit-box-sizing: border-box; /* [5] */
-               -moz-box-sizing: border-box; /* [5] */
                     box-sizing: border-box; /* [5] */
         }
 


### PR DESCRIPTION
It seems safe to remove the `moz` vendor prefix for `box-sizing` now:
http://caniuse.com/#feat=css3-boxsizing